### PR TITLE
[SCR-683] feat: Change category in manifest

### DIFF
--- a/manifest.konnector
+++ b/manifest.konnector
@@ -9,7 +9,7 @@
   "editor": "Cozy",
   "vendor_link": "https://fr.chargemap.com/",
   "categories": [
-    "others"
+    "transport"
   ],
   "fields": {
     "login": {


### PR DESCRIPTION
Replace category in manifest for the konnector to display in transport category in the store